### PR TITLE
Potential fix for code scanning alert no. 27: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/Joelpiccioni/juice-shop-dsa/security/code-scanning/27](https://github.com/Joelpiccioni/juice-shop-dsa/security/code-scanning/27)

To fix this code injection vulnerability, we should avoid using the `$where` operator with user input. Instead, use a standard query operator that does not interpret user input as code. In this case, we can replace the `$where` query with a direct equality match using `{ orderId: id }`. This change should be made on line 18 of `routes/trackOrder.ts`. No additional imports or methods are needed, as this is a standard MongoDB query. The rest of the code can remain unchanged, as the query result will be the same for legitimate values of `id`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
